### PR TITLE
Add experimental support for up to E9M10

### DIFF
--- a/src/doom/wad.cpp
+++ b/src/doom/wad.cpp
@@ -384,10 +384,10 @@ bool WAD::IsMap ( const char *name ) {
 	}
 	if (( name[0] == 'E' ) && ( name[2] == 'M' )) {
 		int episode = name[1], mission = name[3];
-		if (( episode < '1' ) || ( episode > '6' )) {
+		if (( episode < '1' ) || ( episode > '9' )) {
 			return false;
 		}
-		if (( mission < '1' ) || ( mission > '9' )) {
+		if (( mission < '1' ) || ( mission > '10' )) {
 			return false;
 		}
 		if ( name[4] != '\0' ) {


### PR DESCRIPTION
This helps address an issue that didn't allow ZokumBSP to work with ExM10 maps (like, for ex. Sewers in original Xbox UD and WadSmoosh if smooshed in through that) and relaxes limits on what episodes can be supported in the tool.