### PR TITLE
ProcessLevel: disable forced verification of existing nodes

### DIFF
--- a/src/zokumbsp/zenmain.cpp
+++ b/src/zokumbsp/zenmain.cpp
@@ -1499,7 +1499,7 @@ bool ProcessLevel ( char *name, wadList *myList, UINT32 *elapsed ) {
 
 	const wadListDirEntry *dir = myList->FindWAD ( name );
 	DoomLevel *curLevel = new DoomLevel ( name, dir->wad );
-	if ( curLevel->IsValid ( ! config.Nodes.Rebuild ) == false ) {
+	if ( curLevel->IsValid ( false ) == false ) {
 		cprintf ( "This level is not valid... " );
 		cprintf ( "\r\n" );
 		delete curLevel;


### PR DESCRIPTION
It would be nice to be able to build reject tables for maps that use
ZDBSP's extended nodes format ("XNOD") (which, despite the source, is a
cross-port standard). For example `zdbsp -brX blah.wad -o blah.wad`
during development then `zokumbsp -n- -b- -rg blah.wad` as a final step.

Currently this is impossible. Running zokumbsp with `-n-`, so as to
preserve the SEGS/SSECTORS/NODES lumps, triggers an unwanted validation
of the existing content of said lumps, by `ProcessLevel` in zenmain.cpp
passing `true` to `DoomLevel::IsValid`. Naturally `IsValid` does not
recognise XNOD, having been written decades before it was conceived. The
problem is, then the whole program refuses to continue processing a map
it incorrectly believes is corrupt.

It can be worked around by running ZokumBSP first and building broken
nodes which are then discarded, but this is a frustrating waste of the
user's time and CPU. And this assumes the trick works at all - some maps
such as Sunder map15 are so large that ZokumBSP's nodebuilder code
segfaults on them, despite its reject builder being fully able to cope
with the map.

While it would be possible to add code to detect+verify XNOD I suggest
that the validation step is unnecessary and can simply be removed. The
program itself never uses the map's nodes for any other purpose, so it
doesn't matter if it can't read them.