### PR TITLE
Remove CompressSideDefs() compiler warning

### DIFF
--- a/src/zokumbsp/preprocess.cpp
+++ b/src/zokumbsp/preprocess.cpp
@@ -678,7 +678,7 @@ void MapExtraData( DoomLevel *level, const sOptions *config) {
 	   UINT16      sector;               
 	 * */
 
-	int CompressSideDefs(DoomLevel *level, const sOptions *config) {
+	void CompressSideDefs(DoomLevel *level, const sOptions *config) {
 		int sideDefs = level->SideDefCount();
 
 		const wSideDef *sideDef = level->GetSideDefs ();


### PR DESCRIPTION
Function `CompressSideDefs()` is declared an `int` return type but there is no explicit `return` statement.