### PR TITLE
Ignore Doom Builder zokumbsp.cfg

### DIFF
--- a/src/zokumbsp/zenmain.cpp
+++ b/src/zokumbsp/zenmain.cpp
@@ -644,6 +644,8 @@ void ReadConfigFile ( const char *argv [] )
 {
 	FUNCTION_ENTRY ( NULL, "ReadConfigFile", true );
 
+	const char DOOM_BUILDER_CONFIG_HEADER[]  = "compilers\n";
+
 	FILE *configFile = fopen ( CONFIG_FILENAME, "rt" );
 	if ( configFile == NULL ) {
 		char fileName [ 256 ];
@@ -664,7 +666,12 @@ void ReadConfigFile ( const char *argv [] )
 		char lineBuffer [ 256 ];
 		if (fgets ( lineBuffer, sizeof ( lineBuffer ), configFile ) == NULL) {
 			fprintf(stderr, "Input error\n");
+		} else if (strcmp ( lineBuffer, DOOM_BUILDER_CONFIG_HEADER) == 0) {
+			errors = true;
+			fprintf ( stderr, "%s appears to be a Doom Builder config file. Skipping.\n", CONFIG_FILENAME );
+			break;
 		}
+
 		char *basePtr = strupr ( lineBuffer );
 		while ( *basePtr == ' ' ) basePtr++;
 		basePtr = strtok ( basePtr, "\n\x1A" );


### PR DESCRIPTION
Editors forking Doom Builder name their nodebuilder configuration files to match the executable. e.g., ZenNode.exe / ZenNode.cfg. See:

* [Doom Builder X](https://github.com/anotak/doombuilderx/blob/a72c139c33145ca8bb9c2f3a6b701c975fccebad/data/Compilers/Nodebuilders/zokumbsp.cfg)
* [GZDoom-Builder / Ultimate DoomBuilder](https://github.com/jewalky/UltimateDoomBuilder/tree/master/Build/Compilers/Nodebuilders)

Since zokumbsp.exe assumes zokumbsp.cfg contains command line argument presets, it tries to parse the editor's config. The below file:

# zokumbsp.cfg

```
compilers
{
    zokumbsp
    {
        interface = "NodesCompiler";
        program = "zokumbsp.exe";
    }
}

nodebuilders
{
    zokumbsp_fast
    {
        title = "ZokumBSP - Fast (no reject)";
        compiler = "zokumbsp";
        parameters = "-nu -nq -rz %FI -o %FI -l";
    }
}
```

will cause the below output when running: `./zokumbsp.exe -rz -nu -bc "c:\doom2\wads\in.wad" -o "c:\doom2\wads\out.wad"`

```
Based on: ZenNode Version 1.2.1 (c) 1994-2004 Marc Rousseau

Based on: ZenNode Version 1.2.1 (c) 1994-2004 Marc Rousseau

Unrecognized configuration option '          '
Unrecognized configuration option '  '
Unrecognized configuration option ' ZOKUMBSP'
Unrecognized configuration option ' {'
Unrecognized configuration option ' INTERFACE = "NODESCOMPILER";'
Unrecognized configuration option ' PROGRAM = "ZOKUMBSP.EXE";'
Unrecognized configuration option ' }'
Unrecognized configuration option '  '
Unrecognized configuration option '  '
Unrecognized configuration option ' ZOKUMBSP_FAST'
Unrecognized configuration option ' {'
Unrecognized configuration option ' TITLE = "ZOKUMBSP - FAST (NO REJECT)";'
Unrecognized configuration option ' COMPILER = "ZOKUMBSP";'
Unrecognized configuration option ' PARAMETERS = "-NU -NQ -RZ %FI -O %FI -L";'
Unrecognized configuration option ' }'
Unrecognized configuration option '  '
```

I went with the simplest implementation to look for a single line "compilers" string. Otherwise a line counter would have to be added to find if the first non-whitespace phrase matching that string. (Not to mention someone reformatting the config to Egyptian braces style.) _Manual_ string handling in C/C++ does my head in.

I tested this on Windows 10 / MingW64 with zokumbsp.cfg line endings of both Unix `"compilers\n"` & Windows `"compilers\r\n"`. I believe the latter `fgets()` result parses correctly since `fopen()` flag `'t'` is used, and not `'b'`?