### PR TITLE
Add -sx option for percentage output of 65,535 lump size limit

### DIFF
--- a/src/zokumbsp/zennode.hpp
+++ b/src/zokumbsp/zennode.hpp
@@ -355,13 +355,13 @@ struct sGeometryOptions {
 };
 
 struct sStatisticsOptions {
+	int 			MaxSize;
 	bool			ShowVertices;
 	bool			ShowLineDefs;
 	bool			ShowSplits;
 	bool			ShowSectors;
 	bool			ShowThings;
 	bool			ShowTotals;
-	bool			ShowTopSummary;
 	bool			ShowSubSectors;
 	bool			ShowNodes;
 };


### PR DESCRIPTION
1. Remove unused option `-su`. `config.Statistics.ShowTopSummary` is set but isn't used as a flag anywhere in the code, even in commented out sections.
2. Add complete `-s` instructions in help output.
3. Add new option `-sx` ("extra" since `-ss` for "source port" is already declared) to allow showing "%Limit" column output relative to the unsigned integer increase to (2^16 - 1) limit of most source ports including Crispy Doom, PrBoom+, Eternity, and ZDoom.

### `./zokumbsp.exe`

```
Based on: ZenNode Version 1.2.1 (c) 1994-2004 Marc Rousseau

Usage: zokumbsp {-options} filename[.wad] [level{+level}] {-o|x output[.wad]}

 -x+ turn on option   -x- turn off option  * = default

...

Switches to control other options.

  -c      Enable 16 color output.
  -cc     Enable 24bit color output.
  -t      Don't write output file (test mode).

  -s=     Which output stats to show.
    e     Sector count.
    l     Linedef count.
    p     Seg split count.
    n     Nodes count.
    s     Subsector count.
    t     Thing count.
    v     Vertices count.
    a     Show all of the above.
    m     Show a total for all computed levels.
    x     Count percentage by 65536 limit of source ports.

 level - ExMy for DOOM/Heretic or MAPxx for DOOM II/HEXEN.

Example: zokumbsp -b- -r- -sm -na=a file.wad map01+map03
```