### PR TITLE
Partially fix support for RMB options files

### DIFF
--- a/src/zokumbsp/zenmain.cpp
+++ b/src/zokumbsp/zenmain.cpp
@@ -104,7 +104,7 @@ sOptions config;
 
 struct sOptionsRMB {
     const char         *wadName;
-    sRejectOptionRMB   *option [MAX_OPTIONS];
+    sRejectOptionRMB   option [MAX_OPTIONS];
 };
 
 sOptionsRMB rmbOptionTable [MAX_WADS];
@@ -798,8 +798,7 @@ bool ReadOptionsRMB ( const char *wadName, sOptionsRMB *options ) {
 		}
 		sRejectOptionRMB tempOption;
 		if ( ParseOptionRMB ( ++line, buffer, &tempOption ) == true ) {
-			options->option [index]  = new sRejectOptionRMB;
-			*options->option [index] = tempOption;
+			options->option [index] = tempOption;
 			index++;
 		}
 	}
@@ -903,7 +902,10 @@ wadList *getInputFiles ( const char *cmdLine, char *wadFileName )
 				delete wad;
 			} else {
 				if (( config.Reject.UseRMB == true ) && ( index < MAX_WADS )) {
-					if ( ReadOptionsRMB ( wadName, &rmbOptionTable [index] ) == true ) index++;
+					if ( ReadOptionsRMB ( wadName, &rmbOptionTable [index] ) == true ) {
+						config.Reject.rmb = rmbOptionTable[index].option;
+						index++;
+					}
 				} else if ( index == MAX_WADS ) {
 					fprintf ( stderr, "WARNING: Too many wads specified - RMB options ignored" );
 					index++;


### PR DESCRIPTION
RMB options appear broken. Options files are parsed but not acted upon.

RMB options are parsed into an rmbOptionTable array in ZenMain.cpp, but
nothing is done with it afterwards. In particular, config.Reject.rmb is
always passed to CreateREJECT as NULL, so none of the functions dealing
with RMB features in ZenReject.cpp do anything but immediately return.

This patch sets config.Reject.rmb to the last parsed RMB options list,
and changes the struct sOptionsRMB from holding an array of pointers to
sRejectOptionRMB, to an array of the actual objects, because that's what
ZenReject.cpp functions expect.

It is not a complete fix. I can offer no guarantee of its correctness.
In particular the last RMB options file read is always the one passed to
ZenReject. A proper fix would retain the association between *.wad and
corresponding *.rej.

It is strange. The parser is quite sophisticated. The reject table
generator has all the code to apply the effects. But the link between
them is broken. If I had to guess, I'd say the code was incomplete, as
if in the middle of a rewrite, and not more than compile-tested before
release. And seemingly unnoticed by almost all users; I only found one
other reference, a nine-year-old thread with no replies, describing
similar symptoms.[1] I only needed it for a party trick.[2]

[1] https://www.doomworld.com/vb/post/1117023
[2] https://www.doomworld.com/vb/post/2408137